### PR TITLE
feat(history): add pagination

### DIFF
--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -1787,6 +1787,49 @@ svg {
     padding: 0 11px;
 }
 
+.history-pager {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    margin: 0 0 18px;
+}
+
+.history-pager:last-of-type {
+    margin: 22px 0 0;
+}
+
+.history-pager-status {
+    min-width: 7.5rem;
+    color: rgba(255, 255, 255, .58);
+    font-size: 13px;
+    font-weight: 700;
+    text-align: center;
+}
+
+.history-pager-btn {
+    min-height: 36px;
+    padding: 0 14px;
+    color: #e9e7f3;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 36px;
+    border: 1px solid rgba(255, 255, 255, .1);
+    border-radius: 9px;
+    background: rgba(255, 255, 255, .05);
+    text-decoration: none;
+}
+
+a.history-pager-btn:hover {
+    background: rgba(124, 92, 255, .18);
+    border-color: rgba(124, 92, 255, .4);
+}
+
+.history-pager-btn.is-disabled {
+    color: rgba(255, 255, 255, .32);
+    pointer-events: none;
+}
+
 .search-control span {
     color: rgba(255, 255, 255, .42);
     font-size: 12px;

--- a/src/Jellyfin/PlayHistoryRepository.php
+++ b/src/Jellyfin/PlayHistoryRepository.php
@@ -218,6 +218,7 @@ final class PlayHistoryRepository
     {
         $selection = $this->filteredSelection($filters, $now)
             ->orderBy('started_at')->desc()
+            ->orderBy('id')->desc()
             ->limit($filters->limit)
             ->offset($filters->offset);
 

--- a/src/Pages/HistoryController.php
+++ b/src/Pages/HistoryController.php
@@ -15,8 +15,18 @@ final class HistoryController extends Controller
     {
         $filters = $this->filters();
         $repository = new PlayHistoryRepository();
-        $rows = $repository->historyRows($filters);
         $totalFiltered = $repository->historyTotal($filters);
+        $page = $this->currentPage($totalFiltered, $filters->limit);
+        $filters = new HistoryFilters(
+            search: $filters->search,
+            user: $filters->user,
+            library: $filters->library,
+            range: $filters->range,
+            limit: $filters->limit,
+            offset: ($page - 1) * $filters->limit,
+        );
+        $rows = $repository->historyRows($filters);
+        $pages = max(1, (int) ceil($totalFiltered / max(1, $filters->limit)));
 
         $this->render('history/index', [
             'layout' => $this->layout([
@@ -24,7 +34,8 @@ final class HistoryController extends Controller
                 'page' => 'history',
             ]),
             'groups' => $this->groups($rows),
-            'summary' => $this->summary($rows, $totalFiltered, $repository->totalRows()),
+            'summary' => $this->summary($rows, $totalFiltered, $repository->totalRows(), $filters->offset),
+            'pager' => $this->pager($page, $pages, $filters),
             'users' => $repository->users(),
             'filters' => [
                 'search' => $filters->search,
@@ -48,6 +59,47 @@ final class HistoryController extends Controller
             library: trim((string) (Main::captureGetString('library') ?? '')),
             range: $range,
         );
+    }
+
+    private function currentPage(int $total, int $perPage): int
+    {
+        $page = (int) (Main::captureGetString('p') ?? '1');
+        if ($page < 1) {
+            $page = 1;
+        }
+
+        $pages = max(1, (int) ceil($total / max(1, $perPage)));
+
+        return min($page, $pages);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pager(int $page, int $pages, HistoryFilters $filters): array
+    {
+        return [
+            'page' => $page,
+            'pages' => $pages,
+            'prev_url' => $page > 1 ? $this->historyUrl($filters, $page - 1) : '',
+            'next_url' => $page < $pages ? $this->historyUrl($filters, $page + 1) : '',
+        ];
+    }
+
+    private function historyUrl(HistoryFilters $filters, int $page): string
+    {
+        $query = array_filter([
+            'search' => $filters->search,
+            'user' => $filters->user,
+            'library' => $filters->library,
+            'range' => $filters->range !== '30' ? $filters->range : '',
+        ], static fn (string $value): bool => $value !== '');
+
+        if ($page > 1) {
+            $query['p'] = (string) $page;
+        }
+
+        return '/history' . ($query === [] ? '' : '?' . http_build_query($query));
     }
 
     /**
@@ -131,7 +183,7 @@ final class HistoryController extends Controller
      * @param array<int, \Dibi\Row> $rows
      * @return array<string, mixed>
      */
-    private function summary(array $rows, int $totalFiltered, int $totalRows): array
+    private function summary(array $rows, int $totalFiltered, int $totalRows, int $offset): array
     {
         $watchSec = 0;
         $users = [];
@@ -152,6 +204,8 @@ final class HistoryController extends Controller
 
         return [
             'shown' => $shown,
+            'from' => $shown === 0 ? 0 : $offset + 1,
+            'to' => $offset + $shown,
             'total' => $totalRows,
             'filtered_total' => $totalFiltered,
             'unique_users' => count($users),

--- a/templates/_shell.twig
+++ b/templates/_shell.twig
@@ -22,7 +22,7 @@
         <meta name="vapid-public-key" content="{{ vapid_public_key }}">
     {% endif %}
 
-    <link rel="stylesheet" href="/assets/css/dashboard.css?v=20260811-release">
+    <link rel="stylesheet" href="/assets/css/dashboard.css?v=20260814-pager">
     {% for href in module_styles %}
         <link rel="stylesheet" href="{{ href }}">
     {% endfor %}

--- a/templates/history/_pager.twig
+++ b/templates/history/_pager.twig
@@ -1,0 +1,15 @@
+{% if pager.pages > 1 %}
+    <nav class="history-pager" aria-label="History pages">
+        {% if pager.prev_url %}
+            <a class="history-pager-btn" href="{{ pager.prev_url }}">Previous</a>
+        {% else %}
+            <span class="history-pager-btn is-disabled">Previous</span>
+        {% endif %}
+        <span class="history-pager-status">Page {{ pager.page }} of {{ pager.pages }}</span>
+        {% if pager.next_url %}
+            <a class="history-pager-btn" href="{{ pager.next_url }}">Next</a>
+        {% else %}
+            <span class="history-pager-btn is-disabled">Next</span>
+        {% endif %}
+    </nav>
+{% endif %}

--- a/templates/history/index.twig
+++ b/templates/history/index.twig
@@ -47,7 +47,7 @@
 {% block dashboard_footer %}
     <div class="stat-cell">
         <span><i class="dot-purple"></i>Plays shown</span>
-        <strong>{{ summary.from }}-{{ summary.to }} <small>of {{ summary.filtered_total }}</small></strong>
+        <strong>{% if summary.shown > 0 %}{{ summary.from }}-{{ summary.to }} <small>of {{ summary.filtered_total }}</small>{% else %}0 <small>of {{ summary.filtered_total }}</small>{% endif %}</strong>
     </div>
     <div class="stat-cell">
         <span><i class="dot-green"></i>Unique users</span>

--- a/templates/history/index.twig
+++ b/templates/history/index.twig
@@ -3,7 +3,7 @@
 {% block dashboard_header %}
     <div class="header-copy">
         <h1>History</h1>
-        <p>Showing {{ summary.shown }} of {{ summary.filtered_total }} plays</p>
+        <p>{% if summary.shown > 0 %}Showing {{ summary.from }}-{{ summary.to }} of {{ summary.filtered_total }} plays{% else %}Showing 0 of {{ summary.filtered_total }} plays{% endif %}</p>
     </div>
     <form class="filter-bar" method="get" action="/history">
         <label class="search-control">
@@ -36,16 +36,18 @@
     {% if groups is empty %}
         {% include "history/_empty.twig" %}
     {% else %}
+        {% include "history/_pager.twig" %}
         {% for group in groups %}
             {% include "history/_day_group.twig" with { group: group } %}
         {% endfor %}
+        {% include "history/_pager.twig" %}
     {% endif %}
 {% endblock %}
 
 {% block dashboard_footer %}
     <div class="stat-cell">
         <span><i class="dot-purple"></i>Plays shown</span>
-        <strong>{{ summary.shown }} <small>of {{ summary.filtered_total }}</small></strong>
+        <strong>{{ summary.from }}-{{ summary.to }} <small>of {{ summary.filtered_total }}</small></strong>
     </div>
     <div class="stat-cell">
         <span><i class="dot-green"></i>Unique users</span>

--- a/tests/HistoryTemplateTest.php
+++ b/tests/HistoryTemplateTest.php
@@ -19,6 +19,10 @@ final class HistoryTemplateTest extends TestCase
             '{{ summary.from }}-{{ summary.to }} <small>of {{ summary.filtered_total }}</small>',
             $template
         );
+        $this->assertStringContainsString(
+            '0 <small>of {{ summary.filtered_total }}</small>',
+            $template
+        );
         $this->assertStringContainsString('history/_pager.twig', $template);
     }
 }

--- a/tests/HistoryTemplateTest.php
+++ b/tests/HistoryTemplateTest.php
@@ -12,8 +12,13 @@ final class HistoryTemplateTest extends TestCase
 
         $this->assertIsString($template);
         $this->assertStringContainsString(
-            '{{ summary.shown }} <small>of {{ summary.filtered_total }}</small>',
+            'Showing {{ summary.from }}-{{ summary.to }} of {{ summary.filtered_total }} plays',
             $template
         );
+        $this->assertStringContainsString(
+            '{{ summary.from }}-{{ summary.to }} <small>of {{ summary.filtered_total }}</small>',
+            $template
+        );
+        $this->assertStringContainsString('history/_pager.twig', $template);
     }
 }

--- a/tests/PlayHistoryRepositoryTest.php
+++ b/tests/PlayHistoryRepositoryTest.php
@@ -170,6 +170,33 @@ final class PlayHistoryRepositoryTest extends TestCase
         $this->assertSame('Middle', $pageTwo[0]['item_name']);
     }
 
+    public function testHistoryRowsBreakTimestampTiesByIdDesc(): void
+    {
+        $now = new \DateTimeImmutable('2026-06-19 12:00:00');
+        $user = 'PHPUnit History Tiebreak';
+        $startedAt = '2026-06-19 12:00:00';
+
+        $this->insertPlay([
+            'user_name' => $user,
+            'item_name' => 'First inserted',
+            'started_at' => $startedAt,
+        ]);
+        $this->insertPlay([
+            'user_name' => $user,
+            'item_name' => 'Second inserted',
+            'started_at' => $startedAt,
+        ]);
+
+        $rows = $this->repository->historyRows(new HistoryFilters(
+            user: $user,
+            range: 'all',
+        ), $now);
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('Second inserted', $rows[0]['item_name']);
+        $this->assertSame('First inserted', $rows[1]['item_name']);
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/tests/PlayHistoryRepositoryTest.php
+++ b/tests/PlayHistoryRepositoryTest.php
@@ -139,23 +139,28 @@ final class PlayHistoryRepositoryTest extends TestCase
     public function testHistoryRowsHonorLimitAndOffset(): void
     {
         $now = new \DateTimeImmutable('2026-06-19 12:00:00');
+        $user = 'PHPUnit History Pager';
         $this->insertPlay([
             'session_key' => 'phpunit-page-a',
+            'user_name' => $user,
             'item_name' => 'Newest',
             'started_at' => '2026-06-19 12:00:00',
         ]);
         $this->insertPlay([
             'session_key' => 'phpunit-page-b',
+            'user_name' => $user,
             'item_name' => 'Middle',
             'started_at' => '2026-06-19 11:00:00',
         ]);
         $this->insertPlay([
             'session_key' => 'phpunit-page-c',
+            'user_name' => $user,
             'item_name' => 'Oldest',
             'started_at' => '2026-06-19 10:00:00',
         ]);
 
         $pageTwo = $this->repository->historyRows(new HistoryFilters(
+            user: $user,
             range: 'all',
             limit: 1,
             offset: 1,

--- a/tests/PlayHistoryRepositoryTest.php
+++ b/tests/PlayHistoryRepositoryTest.php
@@ -136,6 +136,35 @@ final class PlayHistoryRepositoryTest extends TestCase
         $this->assertContains('PHPUnit Viewer', $this->repository->users());
     }
 
+    public function testHistoryRowsHonorLimitAndOffset(): void
+    {
+        $now = new \DateTimeImmutable('2026-06-19 12:00:00');
+        $this->insertPlay([
+            'session_key' => 'phpunit-page-a',
+            'item_name' => 'Newest',
+            'started_at' => '2026-06-19 12:00:00',
+        ]);
+        $this->insertPlay([
+            'session_key' => 'phpunit-page-b',
+            'item_name' => 'Middle',
+            'started_at' => '2026-06-19 11:00:00',
+        ]);
+        $this->insertPlay([
+            'session_key' => 'phpunit-page-c',
+            'item_name' => 'Oldest',
+            'started_at' => '2026-06-19 10:00:00',
+        ]);
+
+        $pageTwo = $this->repository->historyRows(new HistoryFilters(
+            range: 'all',
+            limit: 1,
+            offset: 1,
+        ), $now);
+
+        $this->assertCount(1, $pageTwo);
+        $this->assertSame('Middle', $pageTwo[0]['item_name']);
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -167,6 +196,33 @@ final class PlayHistoryRepositoryTest extends TestCase
             'isAudioDirect' => false,
             'transcodeReasons' => ['Audio codec not supported'],
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function insertPlay(array $overrides = []): int
+    {
+        $this->dibi->insert('play_history', array_merge([
+            'session_key' => 'phpunit-' . bin2hex(random_bytes(4)),
+            'user_id' => 'phpunit-user',
+            'user_name' => 'PHPUnit Viewer',
+            'item_id' => 'phpunit-item',
+            'item_type' => 'Movie',
+            'item_name' => 'Arrival',
+            'library' => 'Movies',
+            'play_method' => 'DirectPlay',
+            'client' => 'Web',
+            'device' => 'MacBook',
+            'watched_sec' => 600,
+            'runtime_sec' => 3600,
+            'started_at' => '2099-06-19 12:00:00',
+            'updated_at' => '2099-06-19 12:10:00',
+            'is_finished' => 0,
+            'notified' => 1,
+        ], $overrides))->execute();
+
+        return (int) $this->dibi->getInsertId();
     }
 
     private function cleanup(): void


### PR DESCRIPTION
Hello @themartz90,

Today `/history` only shows the first 100 plays. If you have more, there is no way to see the rest 🥵

This adds a simple pager (`?p=`) : Previous / Next, same filters as the current search, and a showing 1–100 of N style count.
100 plays per page, nothing fancy.

Screenshot :

<img width="857" height="215" alt="image" src="https://github.com/user-attachments/assets/6a904aff-f3ab-481a-8499-b50cf3349611" />

Thomas