### PR TITLE
feat: show jellyfin profile pictures for users

### DIFF
--- a/public/api/image.php
+++ b/public/api/image.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Dotenv\Dotenv;
 use Mk\Framework\Config;
 use Mk\Framework\Http\ImageContentType;
+use Mk\Framework\Http\UserAvatarResponse;
 use Mk\Framework\Log;
 
 define('ROOT_DIR', dirname(__DIR__, 2));
@@ -54,15 +55,15 @@ if ($userId !== '') {
     }
 
     $image = fetchJellyfinImage($url, $token, $verifySsl);
-    if ($image === null) {
-        header('Cache-Control: public, max-age=300');
-        http_response_code(404);
+    $response = UserAvatarResponse::fromImage($image);
+    header('Cache-Control: ' . $response['cacheControl']);
+    http_response_code($response['status']);
+    if ($response['body'] === null || $response['contentType'] === null) {
         exit;
     }
 
-    header('Content-Type: ' . $image['contentType']);
-    header('Cache-Control: public, max-age=3600');
-    echo $image['body'];
+    header('Content-Type: ' . $response['contentType']);
+    echo $response['body'];
     exit;
 }
 

--- a/public/api/image.php
+++ b/public/api/image.php
@@ -23,11 +23,48 @@ if (session_status() === PHP_SESSION_ACTIVE) {
 }
 
 $itemId = (string) ($_GET['item'] ?? '');
+$userId = (string) ($_GET['user'] ?? '');
 $type = (string) ($_GET['type'] ?? 'Backdrop');
 $maxWidth = (int) ($_GET['maxWidth'] ?? 1280);
 // kind=series resolves an episode to its parent series so we can show the
 // series poster instead of the per-episode still.
 $kind = (string) ($_GET['kind'] ?? '');
+
+$baseUrl = rtrim((string) Config::get('JELLYFIN_URL', ''), '/');
+$token = (string) Config::get('JELLYFIN_API_TOKEN', Config::get('JELLYFIN_API_KEY', ''));
+
+if ($baseUrl === '' || $token === '') {
+    http_response_code(404);
+    exit;
+}
+
+$verifySsl = Config::bool('JELLYFIN_VERIFY_SSL', true);
+
+if ($userId !== '') {
+    if (!preg_match('/^[A-Za-z0-9_-]+$/', $userId)) {
+        http_response_code(400);
+        exit;
+    }
+
+    $url = $baseUrl . '/Users/' . rawurlencode($userId) . '/Images/Primary'
+        . '?maxWidth=' . max(32, min(256, $maxWidth > 0 ? $maxWidth : 80));
+    $tag = (string) ($_GET['tag'] ?? '');
+    if ($tag !== '' && preg_match('/^[A-Za-z0-9._-]+$/', $tag)) {
+        $url .= '&tag=' . rawurlencode($tag);
+    }
+
+    $image = fetchJellyfinImage($url, $token, $verifySsl);
+    if ($image === null) {
+        header('Cache-Control: public, max-age=300');
+        http_response_code(404);
+        exit;
+    }
+
+    header('Content-Type: ' . $image['contentType']);
+    header('Cache-Control: public, max-age=3600');
+    echo $image['body'];
+    exit;
+}
 
 if ($itemId === '' || !preg_match('/^[A-Za-z0-9_-]+$/', $itemId)) {
     http_response_code(400);
@@ -39,16 +76,7 @@ if (!in_array($type, $allowedTypes, true)) {
     $type = 'Backdrop';
 }
 
-$baseUrl = rtrim((string) Config::get('JELLYFIN_URL', ''), '/');
-$token = (string) Config::get('JELLYFIN_API_TOKEN', Config::get('JELLYFIN_API_KEY', ''));
-
-if ($baseUrl === '' || $token === '') {
-    http_response_code(404);
-    exit;
-}
-
 $fallbackTypes = array_values(array_unique([$type, 'Backdrop', 'Thumb', 'Primary']));
-$verifySsl = Config::bool('JELLYFIN_VERIFY_SSL', true);
 
 // Resolve episode -> series so TV history rows show the series poster.
 // On any failure we keep the original item id (falls back to its own image).
@@ -89,9 +117,27 @@ foreach ($fallbackTypes as $imageType) {
     $url = $baseUrl . '/Items/' . rawurlencode($itemId) . '/Images/' . $imageType
         . '?maxWidth=' . max(100, min(2000, $maxWidth));
 
+    $image = fetchJellyfinImage($url, $token, $verifySsl);
+    if ($image === null) {
+        continue;
+    }
+
+    header('Content-Type: ' . $image['contentType']);
+    header('Cache-Control: public, max-age=300');
+    echo $image['body'];
+    exit;
+}
+
+http_response_code(404);
+
+/**
+ * @return array{body: string, contentType: string}|null
+ */
+function fetchJellyfinImage(string $url, string $token, bool $verifySsl): ?array
+{
     $handle = curl_init($url);
     if ($handle === false) {
-        continue;
+        return null;
     }
 
     curl_setopt_array($handle, [
@@ -115,27 +161,22 @@ foreach ($fallbackTypes as $imageType) {
 
     if ($response === false) {
         Log::logErrorMessage('Jellyfin image request failed: ' . $error, 'image.php');
-        continue;
+
+        return null;
     }
 
     if ($status < 200 || $status >= 300) {
-        continue;
+        return null;
     }
 
     $body = substr((string) $response, $headerSize);
-    if ($body === '') {
-        continue;
-    }
-
     $safeContentType = ImageContentType::normalize($contentType);
-    if ($safeContentType === null) {
-        continue;
+    if ($body === '' || $safeContentType === null) {
+        return null;
     }
 
-    header('Content-Type: ' . $safeContentType);
-    header('Cache-Control: public, max-age=300');
-    echo $body;
-    exit;
+    return [
+        'body' => $body,
+        'contentType' => $safeContentType,
+    ];
 }
-
-http_response_code(404);

--- a/public/assets/css/dashboard.css
+++ b/public/assets/css/dashboard.css
@@ -1360,10 +1360,12 @@ svg {
 }
 
 .watcher-avatar {
+    position: relative;
     display: grid;
     flex: 0 0 30px;
     width: 30px;
     height: 30px;
+    overflow: hidden;
     place-items: center;
     color: #fff;
     font-size: 11px;
@@ -1371,6 +1373,24 @@ svg {
     border-radius: 999px;
     background: linear-gradient(135deg, #7c5cff, #b06bff);
     box-shadow: 0 2px 8px rgba(0, 0, 0, .45);
+}
+
+.watcher-avatar.has-image {
+    color: transparent;
+}
+
+.watcher-avatar-image {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: inherit;
+    opacity: 0;
+}
+
+.watcher-avatar.has-image .watcher-avatar-image {
+    opacity: 1;
 }
 
 .watcher-avatar.is-large,

--- a/public/assets/js/avatars.js
+++ b/public/assets/js/avatars.js
@@ -1,0 +1,43 @@
+(function () {
+    'use strict';
+
+    function reveal(img) {
+        const avatar = img.closest('.watcher-avatar');
+        if (avatar) {
+            avatar.classList.add('has-image');
+        }
+    }
+
+    function bind(root) {
+        const images = (root || document).querySelectorAll('[data-avatar-img]');
+        images.forEach(function (img) {
+            if (img.dataset.avatarBound === '1') {
+                return;
+            }
+            img.dataset.avatarBound = '1';
+
+            img.addEventListener('load', function () {
+                reveal(img);
+            });
+            img.addEventListener('error', function () {
+                img.remove();
+            });
+
+            if (img.complete) {
+                if (img.naturalWidth > 0) {
+                    reveal(img);
+                } else {
+                    img.remove();
+                }
+            }
+        });
+    }
+
+    bind();
+
+    if (typeof MutationObserver === 'function' && document.body) {
+        new MutationObserver(function () {
+            bind();
+        }).observe(document.body, { childList: true, subtree: true });
+    }
+})();

--- a/public/assets/js/now-playing.js
+++ b/public/assets/js/now-playing.js
@@ -43,9 +43,15 @@
     }
 
     function watcher(stream, large) {
+        const avatarUrl = stream.avatarUrl || '';
+        const avatarClass = 'watcher-avatar' + (large ? ' is-large' : '');
+        const img = avatarUrl
+            ? `<img class="watcher-avatar-image" data-avatar-img src="${escapeAttr(avatarUrl)}" alt="">`
+            : '';
+
         return `
             <div class="watcher-row ${large ? 'is-large' : ''}">
-                <span class="watcher-avatar" style="background: ${escapeAttr(stream.avatarBg || '')}">${escapeHtml(stream.initials || 'U')}</span>
+                <span class="${avatarClass}" style="background: ${escapeAttr(stream.avatarBg || '')}">${escapeHtml(stream.initials || 'U')}${img}</span>
                 <span>
                     <strong>${escapeHtml(stream.user || 'Unknown user')}</strong>
                     <small>${escapeHtml(stream.deviceLine || '')}</small>

--- a/src/Http/UserAvatarResponse.php
+++ b/src/Http/UserAvatarResponse.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mk\Framework\Http;
+
+/**
+ * Status and Cache-Control for proxied Jellyfin profile pictures.
+ *
+ * Avatars are personal and the proxy can sit behind auth, so browsers
+ * must cache them privately (including the short-lived 404).
+ */
+final class UserAvatarResponse
+{
+    /**
+     * @param array{body: string, contentType: string}|null $image
+     * @return array{status: int, cacheControl: string, contentType: ?string, body: ?string}
+     */
+    public static function fromImage(?array $image): array
+    {
+        if ($image === null) {
+            return [
+                'status' => 404,
+                'cacheControl' => 'private, max-age=300',
+                'contentType' => null,
+                'body' => null,
+            ];
+        }
+
+        return [
+            'status' => 200,
+            'cacheControl' => 'private, max-age=3600',
+            'contentType' => $image['contentType'],
+            'body' => $image['body'],
+        ];
+    }
+}

--- a/src/Jellyfin/JellyfinClient.php
+++ b/src/Jellyfin/JellyfinClient.php
@@ -81,6 +81,19 @@ final class JellyfinClient
     }
 
     /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function users(): array
+    {
+        $payload = $this->getJson('/Users');
+        if (!is_array($payload)) {
+            return [];
+        }
+
+        return array_values(array_filter($payload, 'is_array'));
+    }
+
+    /**
      * @param array<string, string|int|bool> $query
      */
     public function itemCount(array $query): int

--- a/src/Jellyfin/JellyfinSessionMapper.php
+++ b/src/Jellyfin/JellyfinSessionMapper.php
@@ -120,6 +120,10 @@ final class JellyfinSessionMapper
             'subtitle' => $this->subtitle($item, $type),
             'user' => $user,
             'initials' => $this->initials($user),
+            'avatarUrl' => $this->avatarUrl(
+                (string) ($session['UserId'] ?? ''),
+                (string) ($session['UserPrimaryImageTag'] ?? ''),
+            ),
             'deviceLine' => trim((string) ($session['DeviceName'] ?? 'Unknown device') . ' - ' . (string) ($session['Client'] ?? 'Unknown client')),
             'quality' => $this->quality($item, $session, $isTranscode),
             'isTranscode' => $isTranscode,
@@ -664,6 +668,19 @@ final class JellyfinSessionMapper
         $device = (string) ($session['DeviceName'] ?? '');
 
         return trim($client . ($client !== '' && $device !== '' ? ' - ' : '') . $device) ?: 'Unknown session';
+    }
+
+    /**
+     * Sessions include UserPrimaryImageTag when the account has a photo.
+     * Skip the proxy otherwise so the poller does not 404 every 5 seconds.
+     */
+    private function avatarUrl(string $userId, string $imageTag): string
+    {
+        if (trim($imageTag) === '') {
+            return '';
+        }
+
+        return JellyfinUserAvatars::proxyUrl($userId, $imageTag) ?? '';
     }
 
     private function initials(string $name): string

--- a/src/Jellyfin/JellyfinUserAvatars.php
+++ b/src/Jellyfin/JellyfinUserAvatars.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mk\Framework\Jellyfin;
+
+/**
+ * Builds /api/image.php URLs for Jellyfin profile pictures.
+ *
+ * A user id is enough: the browser hits the proxy, which 404s when there is
+ * no photo (initials stay). /Users is only fetched to map a display name to
+ * an id for older history rows that never stored user_id.
+ */
+final class JellyfinUserAvatars
+{
+    /** @var array<string, string> lowercased name => user id */
+    private array $idsByName = [];
+    private bool $loaded = false;
+
+    public function __construct(private ?JellyfinClient $client = null)
+    {
+    }
+
+    public function url(?string $userId, ?string $userName = null, int $maxWidth = 80): ?string
+    {
+        $id = trim((string) $userId);
+        if ($id === '') {
+            $id = $this->idByName((string) $userName);
+        }
+
+        return self::proxyUrl($id, '', $maxWidth);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $users
+     */
+    public function loadFrom(array $users): void
+    {
+        $this->idsByName = [];
+
+        foreach ($users as $user) {
+            $id = trim((string) ($user['Id'] ?? ''));
+            if ($id === '' || !preg_match('/^[A-Za-z0-9_-]+$/', $id)) {
+                continue;
+            }
+
+            $name = trim((string) ($user['Name'] ?? ''));
+            if ($name !== '') {
+                $this->idsByName[mb_strtolower($name)] = $id;
+            }
+        }
+
+        $this->loaded = true;
+    }
+
+    public static function proxyUrl(string $userId, string $imageTag = '', int $maxWidth = 80): ?string
+    {
+        $userId = trim($userId);
+        if ($userId === '' || !preg_match('/^[A-Za-z0-9_-]+$/', $userId)) {
+            return null;
+        }
+
+        $url = '/api/image.php?user=' . rawurlencode($userId)
+            . '&maxWidth=' . max(32, min(256, $maxWidth));
+
+        $imageTag = trim($imageTag);
+        if ($imageTag !== '' && preg_match('/^[A-Za-z0-9._-]+$/', $imageTag)) {
+            $url .= '&tag=' . rawurlencode($imageTag);
+        }
+
+        return $url;
+    }
+
+    private function idByName(string $userName): string
+    {
+        $name = mb_strtolower(trim($userName));
+        if ($name === '') {
+            return '';
+        }
+
+        $this->ensureLoaded();
+
+        return $this->idsByName[$name] ?? '';
+    }
+
+    private function ensureLoaded(): void
+    {
+        if ($this->loaded) {
+            return;
+        }
+
+        $this->loaded = true;
+
+        try {
+            $this->loadFrom(($this->client ?? new JellyfinClient())->users());
+        } catch (\Throwable) {
+            $this->idsByName = [];
+        }
+    }
+}

--- a/src/Jellyfin/JellyfinUserAvatars.php
+++ b/src/Jellyfin/JellyfinUserAvatars.php
@@ -7,50 +7,15 @@ namespace Mk\Framework\Jellyfin;
 /**
  * Builds /api/image.php URLs for Jellyfin profile pictures.
  *
- * A user id is enough: the browser hits the proxy, which 404s when there is
- * no photo (initials stay). /Users is only fetched to map a display name to
- * an id for older history rows that never stored user_id.
+ * A stored user id is enough: the browser hits the proxy, which 404s when
+ * there is no photo (initials stay). Rows without an id keep initials so
+ * History never waits on Jellyfin.
  */
 final class JellyfinUserAvatars
 {
-    /** @var array<string, string> lowercased name => user id */
-    private array $idsByName = [];
-    private bool $loaded = false;
-
-    public function __construct(private ?JellyfinClient $client = null)
+    public function url(?string $userId, int $maxWidth = 80): ?string
     {
-    }
-
-    public function url(?string $userId, ?string $userName = null, int $maxWidth = 80): ?string
-    {
-        $id = trim((string) $userId);
-        if ($id === '') {
-            $id = $this->idByName((string) $userName);
-        }
-
-        return self::proxyUrl($id, '', $maxWidth);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $users
-     */
-    public function loadFrom(array $users): void
-    {
-        $this->idsByName = [];
-
-        foreach ($users as $user) {
-            $id = trim((string) ($user['Id'] ?? ''));
-            if ($id === '' || !preg_match('/^[A-Za-z0-9_-]+$/', $id)) {
-                continue;
-            }
-
-            $name = trim((string) ($user['Name'] ?? ''));
-            if ($name !== '') {
-                $this->idsByName[mb_strtolower($name)] = $id;
-            }
-        }
-
-        $this->loaded = true;
+        return self::proxyUrl((string) $userId, '', $maxWidth);
     }
 
     public static function proxyUrl(string $userId, string $imageTag = '', int $maxWidth = 80): ?string
@@ -69,32 +34,5 @@ final class JellyfinUserAvatars
         }
 
         return $url;
-    }
-
-    private function idByName(string $userName): string
-    {
-        $name = mb_strtolower(trim($userName));
-        if ($name === '') {
-            return '';
-        }
-
-        $this->ensureLoaded();
-
-        return $this->idsByName[$name] ?? '';
-    }
-
-    private function ensureLoaded(): void
-    {
-        if ($this->loaded) {
-            return;
-        }
-
-        $this->loaded = true;
-
-        try {
-            $this->loadFrom(($this->client ?? new JellyfinClient())->users());
-        } catch (\Throwable) {
-            $this->idsByName = [];
-        }
     }
 }

--- a/src/Jellyfin/PlaybackStatisticsService.php
+++ b/src/Jellyfin/PlaybackStatisticsService.php
@@ -30,6 +30,8 @@ final class PlaybackStatisticsService
     /** @var array<string, array<int, string>>|null Excluded-library locations, fetched once per render. */
     private ?array $locationsCache = null;
 
+    private ?JellyfinUserAvatars $avatars = null;
+
     /**
      * @return array<string, mixed>
      */
@@ -409,7 +411,15 @@ final class PlaybackStatisticsService
         foreach ($rows as $row) {
             $name = (string) ($row['user_name'] ?? 'Unknown user');
             $key = $name !== '' ? $name : 'Unknown user';
-            $users[$key] ??= ['user' => $key, 'min' => 0, 'plays' => 0];
+            $users[$key] ??= [
+                'user' => $key,
+                'user_id' => trim((string) ($row['user_id'] ?? '')),
+                'min' => 0,
+                'plays' => 0,
+            ];
+            if ($users[$key]['user_id'] === '') {
+                $users[$key]['user_id'] = trim((string) ($row['user_id'] ?? ''));
+            }
             $users[$key]['min'] += (int) floor(((int) $row['watched_sec']) / 60);
             $users[$key]['plays']++;
         }
@@ -422,11 +432,16 @@ final class PlaybackStatisticsService
             $color = self::COLORS[$index % count(self::COLORS)];
             $index++;
             $avg = (int) round((int) $user['min'] / max(1, (int) $user['plays']));
+            $avatarBg = 'linear-gradient(135deg,' . $color . ',#3b9eff)';
 
             return [
                 'user' => $user['user'],
                 'initials' => $this->initials((string) $user['user']),
-                'avatarBg' => 'linear-gradient(135deg,' . $color . ',#3b9eff)',
+                'avatarBg' => $avatarBg,
+                'avatarUrl' => $this->avatars()->url(
+                    (string) $user['user_id'],
+                    (string) $user['user'],
+                ) ?? '',
                 'color' => $color,
                 'watch' => $this->duration(((int) $user['min']) * 60),
                 'plays' => $this->comma((int) $user['plays']),
@@ -848,6 +863,11 @@ final class PlaybackStatisticsService
     private function comma(int $value): string
     {
         return number_format($value);
+    }
+
+    private function avatars(): JellyfinUserAvatars
+    {
+        return $this->avatars ??= new JellyfinUserAvatars($this->client);
     }
 
     private function initials(string $name): string

--- a/src/Jellyfin/PlaybackStatisticsService.php
+++ b/src/Jellyfin/PlaybackStatisticsService.php
@@ -438,10 +438,7 @@ final class PlaybackStatisticsService
                 'user' => $user['user'],
                 'initials' => $this->initials((string) $user['user']),
                 'avatarBg' => $avatarBg,
-                'avatarUrl' => $this->avatars()->url(
-                    (string) $user['user_id'],
-                    (string) $user['user'],
-                ) ?? '',
+                'avatarUrl' => $this->avatars()->url((string) $user['user_id']) ?? '',
                 'color' => $color,
                 'watch' => $this->duration(((int) $user['min']) * 60),
                 'plays' => $this->comma((int) $user['plays']),
@@ -867,7 +864,7 @@ final class PlaybackStatisticsService
 
     private function avatars(): JellyfinUserAvatars
     {
-        return $this->avatars ??= new JellyfinUserAvatars($this->client);
+        return $this->avatars ??= new JellyfinUserAvatars();
     }
 
     private function initials(string $name): string

--- a/src/Pages/HistoryController.php
+++ b/src/Pages/HistoryController.php
@@ -6,6 +6,7 @@ namespace Mk\Framework\Pages;
 
 use Mk\Framework\Controller;
 use Mk\Framework\Jellyfin\HistoryFilters;
+use Mk\Framework\Jellyfin\JellyfinUserAvatars;
 use Mk\Framework\Jellyfin\PlayHistoryRepository;
 use Mk\Framework\Main;
 
@@ -108,6 +109,7 @@ final class HistoryController extends Controller
      */
     private function groups(array $rows): array
     {
+        $avatars = new JellyfinUserAvatars();
         $groups = [];
         $today = (new \DateTimeImmutable('today'))->format('Y-m-d');
         $yesterday = (new \DateTimeImmutable('yesterday'))->format('Y-m-d');
@@ -130,7 +132,7 @@ final class HistoryController extends Controller
                 ];
             }
 
-            $play = $this->rowView($row, $startedAt);
+            $play = $this->rowView($row, $startedAt, $avatars);
             $groups[$dayKey]['watch_sec'] += (int) $row['watched_sec'];
             $groups[$dayKey]['plays'][] = $play;
         }
@@ -149,7 +151,7 @@ final class HistoryController extends Controller
     /**
      * @return array<string, mixed>
      */
-    private function rowView(\Dibi\Row $row, \DateTimeImmutable $startedAt): array
+    private function rowView(\Dibi\Row $row, \DateTimeImmutable $startedAt, JellyfinUserAvatars $avatars): array
     {
         $itemType = (string) $row['item_type'];
         $isTranscode = (string) $row['play_method'] === 'Transcode';
@@ -158,11 +160,15 @@ final class HistoryController extends Controller
         $completion = $runtimeSec > 0 ? min(100, (int) round(($watchedSec / $runtimeSec) * 100)) : 0;
         $seriesName = (string) ($row['series_name'] ?? '');
         $itemName = (string) ($row['item_name'] ?? 'Unknown title');
+        $user = (string) ($row['user_name'] ?? 'Unknown user');
+        $userId = (string) ($row['user_id'] ?? '');
 
         return [
             'time' => $startedAt->format('H:i'),
-            'user' => (string) ($row['user_name'] ?? 'Unknown user'),
-            'initials' => $this->initials((string) ($row['user_name'] ?? 'Unknown user')),
+            'user' => $user,
+            'initials' => $this->initials($user),
+            'avatarBg' => $this->avatarBg($userId !== '' ? $userId : $user),
+            'avatarUrl' => $avatars->url($userId, $user) ?? '',
             'title' => $itemType === 'Episode' && $seriesName !== '' ? $seriesName : $itemName,
             'sub' => $itemType === 'Episode'
                 ? trim((string) ($row['season_ep'] ?? '') . ' - ' . $itemName, ' -')
@@ -239,6 +245,18 @@ final class HistoryController extends Controller
         }
 
         return substr($letters !== '' ? $letters : 'U', 0, 2);
+    }
+
+    private function avatarBg(string $seed): string
+    {
+        $gradients = [
+            'linear-gradient(135deg,#7c5cff,#b06bff)',
+            'linear-gradient(135deg,#f0913a,#f7b955)',
+            'linear-gradient(135deg,#1fb6a6,#34d8a6)',
+            'linear-gradient(135deg,#3b9eff,#6f7bff)',
+        ];
+
+        return $gradients[abs(crc32($seed)) % count($gradients)];
     }
 
     /**

--- a/src/Pages/HistoryController.php
+++ b/src/Pages/HistoryController.php
@@ -168,7 +168,7 @@ final class HistoryController extends Controller
             'user' => $user,
             'initials' => $this->initials($user),
             'avatarBg' => $this->avatarBg($userId !== '' ? $userId : $user),
-            'avatarUrl' => $avatars->url($userId, $user) ?? '',
+            'avatarUrl' => $avatars->url($userId) ?? '',
             'title' => $itemType === 'Episode' && $seriesName !== '' ? $seriesName : $itemName,
             'sub' => $itemType === 'Episode'
                 ? trim((string) ($row['season_ep'] ?? '') . ' - ' . $itemName, ' -')

--- a/templates/_avatar.twig
+++ b/templates/_avatar.twig
@@ -1,0 +1,8 @@
+{% set avatar_initials = initials|default('U') %}
+{% set avatar_bg = bg|default('linear-gradient(135deg, #7c5cff, #b06bff)') %}
+{% set avatar_url = url|default('') %}
+<span class="watcher-avatar{% if large|default(false) %} is-large{% endif %}"
+    {% if bg is defined or avatar_url %}
+        style="background: {{ avatar_bg }}"
+    {% endif %}
+>{{ avatar_initials }}{% if avatar_url %}<img class="watcher-avatar-image" data-avatar-img src="{{ avatar_url }}" alt="">{% endif %}</span>

--- a/templates/_shell.twig
+++ b/templates/_shell.twig
@@ -22,7 +22,7 @@
         <meta name="vapid-public-key" content="{{ vapid_public_key }}">
     {% endif %}
 
-    <link rel="stylesheet" href="/assets/css/dashboard.css?v=20260814-pager">
+    <link rel="stylesheet" href="/assets/css/dashboard.css?v=20260814-avatars">
     {% for href in module_styles %}
         <link rel="stylesheet" href="{{ href }}">
     {% endfor %}
@@ -88,6 +88,7 @@
 <script src="/assets/js/server-stats.js?v=20260809-settings"></script>
 <script src="/assets/js/nav-count.js?v=20260809-settings"></script>
 <script src="/assets/js/update-status.js?v=20260810-update"></script>
+<script src="/assets/js/avatars.js?v=20260814-avatars"></script>
 <script src="/assets/js/release-highlights.js?v=20260811-release"></script>
 {% for src in module_scripts %}
     <script src="{{ src }}"></script>

--- a/templates/history/_history_row.twig
+++ b/templates/history/_history_row.twig
@@ -1,7 +1,7 @@
 <article class="history-row">
     <div class="history-time">{{ play.time }}</div>
     <div class="history-user">
-        <span class="watcher-avatar">{{ play.initials }}</span>
+        {% include "_avatar.twig" with { initials: play.initials, bg: play.avatarBg, url: play.avatarUrl } only %}
         <strong>{{ play.user }}</strong>
     </div>
     <div class="history-item">

--- a/templates/now_playing/_stream_card.twig
+++ b/templates/now_playing/_stream_card.twig
@@ -21,7 +21,7 @@
         </div>
 
         <div class="watcher-row">
-            <span class="watcher-avatar" style="background: {{ stream.avatarBg }}">{{ stream.initials }}</span>
+            {% include "_avatar.twig" with { initials: stream.initials, bg: stream.avatarBg, url: stream.avatarUrl } only %}
             <span>
                 <strong>{{ stream.user }}</strong>
                 <small>{{ stream.deviceLine }}</small>

--- a/templates/now_playing/index.twig
+++ b/templates/now_playing/index.twig
@@ -61,5 +61,5 @@
 {% endblock %}
 
 {% block page_scripts %}
-    <script src="/assets/js/now-playing.js?v=20260730-live"></script>
+    <script src="/assets/js/now-playing.js?v=20260814-avatars"></script>
 {% endblock %}

--- a/templates/statistics/index.twig
+++ b/templates/statistics/index.twig
@@ -101,7 +101,7 @@
                 <div class="stats-user-list">
                     {% for user in stats.topUsers %}
                         <div class="stats-user-row">
-                            <span class="watcher-avatar" style="background: {{ user.avatarBg }}">{{ user.initials }}</span>
+                            {% include "_avatar.twig" with { initials: user.initials, bg: user.avatarBg, url: user.avatarUrl } only %}
                             <div>
                                 <p><strong>{{ user.user }}</strong><small>{{ user.watch }}</small></p>
                                 <span class="stats-track"><i style="width: {{ user.w }}; background: {{ user.color }}"></i></span>
@@ -281,7 +281,7 @@
             {% for user in stats.usersTable %}
                 <article class="stats-user-table-row">
                     <div class="stats-user-name">
-                        <span class="watcher-avatar" style="background: {{ user.avatarBg }}">{{ user.initials }}</span>
+                        {% include "_avatar.twig" with { initials: user.initials, bg: user.avatarBg, url: user.avatarUrl } only %}
                         <strong>{{ user.user }}</strong>
                     </div>
                     <span class="history-mono">{{ user.watch }}</span>

--- a/tests/HistoryTemplateTest.php
+++ b/tests/HistoryTemplateTest.php
@@ -25,4 +25,13 @@ final class HistoryTemplateTest extends TestCase
         );
         $this->assertStringContainsString('history/_pager.twig', $template);
     }
+
+    public function testHistoryRowsUseSharedAvatarPartial(): void
+    {
+        $template = file_get_contents(TEMPLATES_DIR . '/history/_history_row.twig');
+
+        $this->assertIsString($template);
+        $this->assertStringContainsString('_avatar.twig', $template);
+        $this->assertStringContainsString('play.avatarUrl', $template);
+    }
 }

--- a/tests/JellyfinSessionMapperTest.php
+++ b/tests/JellyfinSessionMapperTest.php
@@ -35,6 +35,10 @@ final class JellyfinSessionMapperTest extends TestCase
         $this->assertSame('S3 - E8 - It Reaches Out', $stream['subtitle']);
         $this->assertSame('Maya Okafor', $stream['user']);
         $this->assertSame('MO', $stream['initials']);
+        $this->assertSame(
+            '/api/image.php?user=user-1&maxWidth=80&tag=maya-face',
+            $stream['avatarUrl']
+        );
         $this->assertSame('Living Room Shield - Android TV', $stream['deviceLine']);
         $this->assertSame('4K HEVC HDR', $stream['quality']);
         $this->assertTrue($stream['isTranscode']);
@@ -67,6 +71,7 @@ final class JellyfinSessionMapperTest extends TestCase
         $this->assertFalse($stream['isTranscode']);
         $this->assertTrue($stream['isDirect']);
         $this->assertSame('Direct Play', $stream['methodLabel']);
+        $this->assertSame('', $stream['avatarUrl']);
         $this->assertStringContainsString('/api/image.php?item=item-2&type=Backdrop', $stream['backdrop']);
     }
 
@@ -79,6 +84,7 @@ final class JellyfinSessionMapperTest extends TestCase
             'Id' => 'session-1',
             'UserId' => 'user-1',
             'UserName' => 'Maya Okafor',
+            'UserPrimaryImageTag' => 'maya-face',
             'Client' => 'Android TV',
             'DeviceName' => 'Living Room Shield',
             'PlayState' => [

--- a/tests/JellyfinUserAvatarsTest.php
+++ b/tests/JellyfinUserAvatarsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Mk\Framework\Jellyfin\JellyfinUserAvatars;
+use PHPUnit\Framework\TestCase;
+
+final class JellyfinUserAvatarsTest extends TestCase
+{
+    public function testProxyUrlRequiresAUserId(): void
+    {
+        $this->assertNull(JellyfinUserAvatars::proxyUrl(''));
+        $this->assertNull(JellyfinUserAvatars::proxyUrl('user/1'));
+        $this->assertSame(
+            '/api/image.php?user=user-1&maxWidth=80',
+            JellyfinUserAvatars::proxyUrl('user-1')
+        );
+        $this->assertSame(
+            '/api/image.php?user=user-1&maxWidth=80&tag=abc123',
+            JellyfinUserAvatars::proxyUrl('user-1', 'abc123')
+        );
+        $this->assertSame(
+            '/api/image.php?user=user-1&maxWidth=80',
+            JellyfinUserAvatars::proxyUrl('user-1', 'tag with spaces')
+        );
+    }
+
+    public function testUrlUsesAUserIdWithoutLookingUpUsers(): void
+    {
+        $avatars = new JellyfinUserAvatars();
+
+        $this->assertSame(
+            '/api/image.php?user=user-1&maxWidth=80',
+            $avatars->url('user-1')
+        );
+        $this->assertNull($avatars->url('user/1'));
+    }
+
+    public function testUrlResolvesAMissingIdFromTheUserDirectory(): void
+    {
+        $avatars = new JellyfinUserAvatars();
+        $avatars->loadFrom([
+            [
+                'Id' => 'user-with-photo',
+                'Name' => 'Maya Okafor',
+            ],
+            [
+                'Id' => 'user-2',
+                'Name' => 'Sam',
+            ],
+        ]);
+
+        $this->assertSame(
+            '/api/image.php?user=user-with-photo&maxWidth=80',
+            $avatars->url('', 'Maya Okafor')
+        );
+        $this->assertSame(
+            '/api/image.php?user=user-2&maxWidth=80',
+            $avatars->url('', 'sam')
+        );
+        $this->assertNull($avatars->url('', 'Nobody'));
+        $this->assertNull($avatars->url('', ''));
+    }
+}

--- a/tests/JellyfinUserAvatarsTest.php
+++ b/tests/JellyfinUserAvatarsTest.php
@@ -36,29 +36,11 @@ final class JellyfinUserAvatarsTest extends TestCase
         $this->assertNull($avatars->url('user/1'));
     }
 
-    public function testUrlResolvesAMissingIdFromTheUserDirectory(): void
+    public function testUrlKeepsInitialsWhenTheUserIdIsMissing(): void
     {
         $avatars = new JellyfinUserAvatars();
-        $avatars->loadFrom([
-            [
-                'Id' => 'user-with-photo',
-                'Name' => 'Maya Okafor',
-            ],
-            [
-                'Id' => 'user-2',
-                'Name' => 'Sam',
-            ],
-        ]);
 
-        $this->assertSame(
-            '/api/image.php?user=user-with-photo&maxWidth=80',
-            $avatars->url('', 'Maya Okafor')
-        );
-        $this->assertSame(
-            '/api/image.php?user=user-2&maxWidth=80',
-            $avatars->url('', 'sam')
-        );
-        $this->assertNull($avatars->url('', 'Nobody'));
-        $this->assertNull($avatars->url('', ''));
+        $this->assertNull($avatars->url(''));
+        $this->assertNull($avatars->url(null));
     }
 }

--- a/tests/UserAvatarResponseTest.php
+++ b/tests/UserAvatarResponseTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Mk\Framework\Http\UserAvatarResponse;
+use PHPUnit\Framework\TestCase;
+
+final class UserAvatarResponseTest extends TestCase
+{
+    public function testMissIsAPrivatelyCachedNotFound(): void
+    {
+        $response = UserAvatarResponse::fromImage(null);
+
+        $this->assertSame(404, $response['status']);
+        $this->assertSame('private, max-age=300', $response['cacheControl']);
+        $this->assertNull($response['contentType']);
+        $this->assertNull($response['body']);
+    }
+
+    public function testHitIsAPrivatelyCachedImage(): void
+    {
+        $response = UserAvatarResponse::fromImage([
+            'body' => 'fake-jpeg',
+            'contentType' => 'image/jpeg',
+        ]);
+
+        $this->assertSame(200, $response['status']);
+        $this->assertSame('private, max-age=3600', $response['cacheControl']);
+        $this->assertSame('image/jpeg', $response['contentType']);
+        $this->assertSame('fake-jpeg', $response['body']);
+    }
+
+    public function testImageProxyWiresAvatarResponsesAndRejectsBadUserIds(): void
+    {
+        $source = file_get_contents(ROOT_DIR . '/public/api/image.php');
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString('UserAvatarResponse::fromImage', $source);
+        $this->assertStringContainsString("header('Cache-Control: ' . \$response['cacheControl'])", $source);
+    }
+}


### PR DESCRIPTION
Hello @themartz90,

User names currently only show initials. If Jellyfin has a profile picture, it would be nicer to use it 😄

This PR shows those photos on Now Playing, Statistics, and History, and falls back to initials when there is no image.

Screenshot (nice pp 🙈) :

<img width="264" height="169" alt="image" src="https://github.com/user-attachments/assets/15b10bff-7a62-4099-8cc2-bae7b68ad58d" />

Thomas